### PR TITLE
[Server] Set up MySQL Env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,20 @@
+MYSQL_ROOT_PASSWORD=$(shell cat db/password.txt)
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down -v --remove-orphans
+
+migrate_up:
+	migrate -path app/infrastructure/mysql/db/schema -database "mysql://root:password@tcp(localhost:3306)/example" up
+
+migrate_down:
+	migrate -path app/infrastructure/mysql/db/schema -database "mysql://root:password@tcp(localhost:3306)/example" down
+
+exec_db:
+	docker compose exec db mysql -u root -p$(MYSQL_ROOT_PASSWORD) example
+
 test:
 	go test -cover ./... -coverprofile=cover.out
 	go tool cover -html=cover.out

--- a/app/infrastructure/mysql/db/schema/000001_log.down.sql
+++ b/app/infrastructure/mysql/db/schema/000001_log.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS logs;

--- a/app/infrastructure/mysql/db/schema/000001_log.up.sql
+++ b/app/infrastructure/mysql/db/schema/000001_log.up.sql
@@ -1,0 +1,12 @@
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS `logs` (
+  `log_level` VARCHAR(100) NOT NULL COMMENT 'Log_Level',
+  `date` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP COMMENT 'Date',
+  `destination_service` VARCHAR(100) NOT NULL COMMENT 'Destination_Service',
+  `source_service` VARCHAR(100) NOT NULL COMMENT 'Source_Service',
+  `request_type` VARCHAR(100) NOT NULL COMMENT 'Request_Type',
+  `content` TEXT NOT NULL COMMENT 'Content'
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+COMMIT;

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,36 +15,48 @@ services:
     ports:
       - 8080:8080
 
-# The commented out section below is an example of how to define a PostgreSQL
-# database that your application can use. `depends_on` tells Docker Compose to
-# start the database before your application. The `db-data` volume persists the
-# database data between container restarts. The `db-password` secret is used
-# to set the database password. You must create `db/password.txt` and add
-# a password of your choosing to it before running `docker compose up`.
-#     depends_on:
-#       db:
-#         condition: service_healthy
-#   db:
-#     image: postgres
-#     restart: always
-#     user: postgres
-#     secrets:
-#       - db-password
-#     volumes:
-#       - db-data:/var/lib/postgresql/data
-#     environment:
-#       - POSTGRES_DB=example
-#       - POSTGRES_PASSWORD_FILE=/run/secrets/db-password
-#     expose:
-#       - 5432
-#     healthcheck:
-#       test: [ "CMD", "pg_isready" ]
-#       interval: 10s
-#       timeout: 5s
-#       retries: 5
-# volumes:
-#   db-data:
-# secrets:
-#   db-password:
-#     file: db/password.txt
+    # The commented out section below is an example of how to define a MySQL
+    # database that your application can use. `depends_on` tells Docker Compose to
+    # start the database before your application. The `db-data` volume persists the
+    # database data between container restarts. The `db-password` secret is used
+    # to set the database password. You must create `db/password.txt` and add
+    # a password of your choosing to it before running `docker compose up`.
+    depends_on:
+      db:
+        condition: service_healthy
 
+  phpmyadmin:
+    image: phpmyadmin
+    depends_on:
+      - db
+    environment:
+      - PMA_HOSTS=db
+      - PMA_USER=root
+      - PMA_PASSWORD=password
+    ports:
+      - "3001:80"
+  db:
+    image: mysql:8
+    restart: always
+    user: mysql
+    volumes:
+      - db-data:/var/lib/mysql
+    environment:
+      - MYSQL_DATABASE=example
+      - MYSQL_ROOT_PASSWORD_FILE=/run/secrets/db-password
+    secrets:
+      - db-password
+    ports:
+      - 3306:3306
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  db-data:
+
+secrets:
+  db-password:
+    file: db/password.txt

--- a/db/password.txt
+++ b/db/password.txt
@@ -1,0 +1,1 @@
+password


### PR DESCRIPTION
## Issue Number
#4 

## Implementation Summary
Set up MySQL Env using `docker-compose`

## Scope of Impact
When using DB, we use this.

## Particular points to check
None

## Test
```
$ make up
$ make migrate_up
```
We can show the creation of table by using `phpadmin` (localhost:3001).

## Schedule
The date and time you want to merge.
