### PR TITLE
[Server]implement listlog feature in presentation layer.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/google/cel-go v0.21.0 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -40,6 +40,8 @@ github.com/google/cel-go v0.21.0/go.mod h1:rHUlWCcBKgyEk+eV03RPdZUekPp6YcJwV0Fxu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9 h1:O2Tfq5qg4qc4AmwVlvv0oLiVAGB7enBSJ2x2DqQFi38=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=

--- a/internal/server/presentation/log_response.go
+++ b/internal/server/presentation/log_response.go
@@ -1,6 +1,17 @@
 package presentation
 
+import "time"
+
 type AmqpLogResponse struct {
 	StatusCode int    `json:"status_code"`
 	Message    string `json:"message"`
+}
+
+type HttpLogListResponse struct {
+	LogLevel           string    `json:"log_level"`
+	Date               time.Time `json:"date"`
+	SourceService      string    `json:"source_service"`
+	DestinationService string    `json:"destination_service"`
+	RequestType        string    `json:"request_type"`
+	Content            string    `json:"content"`
 }

--- a/internal/server/presentation/log_test.go
+++ b/internal/server/presentation/log_test.go
@@ -4,11 +4,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"testing"
 	"time"
 
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/google/go-cmp/cmp"
 	amqp "github.com/rabbitmq/amqp091-go"
 
 	"go.uber.org/mock/gomock"
@@ -17,9 +20,26 @@ import (
 	"log_service/internal/utils"
 )
 
+type errorWriterResponse struct {
+	statusCode int
+	body       string
+}
+
+func (e *errorWriterResponse) Header() http.Header {
+	return http.Header{}
+}
+
+func (e *errorWriterResponse) Write(p []byte) (int, error) {
+	e.body = string(p)
+	return 0, errors.New("failed to encode logs")
+}
+
+func (e *errorWriterResponse) WriteHeader(statusCode int) {
+	e.statusCode = statusCode
+}
+
 func TestNewAMQPLogHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	mockInsertUseCase := usecase.NewMockIInsertLogUseCase(ctrl)
 	handler := NewAMQPLogHandler(mockInsertUseCase, &amqp.Channel{})
@@ -165,4 +185,138 @@ func testMsg(t *testing.T, fixedTime time.Time) (AMQPLogRequest, amqp.Delivery) 
 
 	msg := amqp.Delivery{Body: payload.Bytes()}
 	return logRequest, msg
+}
+
+func SetupLogListTest(t *testing.T) (*gomock.Controller, *usecase.MockIListLogsUseCase, *HttpLogHandler) {
+	ctrl := gomock.NewController(t)
+	mockListUseCase := usecase.NewMockIListLogsUseCase(ctrl)
+	handler := NewHttpLogHandler(mockListUseCase)
+	return ctrl, mockListUseCase, handler
+}
+
+func TestHandleLogList(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		_, mockListUseCase, handler := SetupLogListTest(t)
+
+		now := time.Now()
+		expectedLogs := []*usecase.ListLogDto{
+			{
+				LogLevel:           "INFO",
+				Date:               now,
+				DestinationService: "ServiceA",
+				SourceService:      "ServiceB",
+				RequestType:        "GET",
+				Content:            "First log message",
+			},
+			{
+				LogLevel:           "ERROR",
+				Date:               now,
+				DestinationService: "ServiceC",
+				SourceService:      "ServiceD",
+				RequestType:        "POST",
+				Content:            "Second log message",
+			},
+		}
+
+		mockListUseCase.EXPECT().ListLogs(gomock.Any()).Return(expectedLogs, nil).Times(1)
+
+		req, err := http.NewRequest("GET", "/logs", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rr := httptest.NewRecorder()
+
+		handler.HandleLogList(rr, req)
+
+		if status := rr.Code; status != http.StatusOK {
+			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusOK)
+		}
+
+		expectedResponse := []HttpLogListResponse{
+			{
+				LogLevel:           "INFO",
+				Date:               now,
+				DestinationService: "ServiceA",
+				SourceService:      "ServiceB",
+				RequestType:        "GET",
+				Content:            "First log message",
+			},
+			{
+				LogLevel:           "ERROR",
+				Date:               now,
+				DestinationService: "ServiceC",
+				SourceService:      "ServiceD",
+				RequestType:        "POST",
+				Content:            "Second log message",
+			},
+		}
+
+		var got []HttpLogListResponse
+		if err := json.NewDecoder(rr.Body).Decode(&got); err != nil {
+			t.Fatalf("Failed to decode response body: %v", err)
+		}
+
+		if diff := cmp.Diff(expectedResponse, got); diff != "" {
+			t.Errorf("handler returned unexpected JSON (-want +got):\n%s", diff)
+		}
+	})
+
+	t.Run("ListLogs Failure", func(t *testing.T) {
+		_, mockListUseCase, handler := SetupLogListTest(t)
+
+		mockListUseCase.EXPECT().ListLogs(gomock.Any()).Return(nil, errors.New("failed to list logs")).Times(1)
+
+		req, err := http.NewRequest("GET", "/logs", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rr := httptest.NewRecorder()
+
+		handler.HandleLogList(rr, req)
+
+		if status := rr.Code; status != http.StatusInternalServerError {
+			t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusInternalServerError)
+		}
+
+		expectedError := "Internal Server Error: failed to list logs\n"
+		if rr.Body.String() != expectedError {
+			t.Errorf("handler returned unexpected error message: got %v want %v", rr.Body.String(), expectedError)
+		}
+	})
+
+	t.Run("Encode Failure", func(t *testing.T) {
+		_, mockListUseCase, handler := SetupLogListTest(t)
+
+		time := time.Now()
+		logs := []*usecase.ListLogDto{
+			{
+				LogLevel:           "INFO",
+				Date:               time,
+				DestinationService: "ServiceA",
+				SourceService:      "ServiceB",
+				RequestType:        "GET",
+				Content:            "First log message",
+			},
+		}
+		mockListUseCase.EXPECT().ListLogs(gomock.Any()).Return(logs, nil).Times(1)
+
+		errorWriter := &errorWriterResponse{}
+
+		req, err := http.NewRequest("GET", "/logs", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		handler.HandleLogList(errorWriter, req)
+
+		if errorWriter.statusCode != http.StatusInternalServerError {
+			t.Errorf("handler returned wrong status code: got %v want %v", errorWriter.statusCode, http.StatusInternalServerError)
+		}
+
+		expected := "Internal Server Error: failed to encode logs\n"
+		if errorWriter.body != expected {
+			t.Errorf("handler returned unexpected error message: got %v want %v", errorWriter.body, expected)
+		}
+	})
+
 }

--- a/internal/server/usecase/list_log_mock.go
+++ b/internal/server/usecase/list_log_mock.go
@@ -6,7 +6,6 @@ package usecase
 
 import (
 	context "context"
-	domain "log_service/internal/server/domain"
 	reflect "reflect"
 
 	gomock "go.uber.org/mock/gomock"
@@ -36,10 +35,10 @@ func (m *MockIListLogsUseCase) EXPECT() *MockIListLogsUseCaseMockRecorder {
 }
 
 // ListLogs mocks base method.
-func (m *MockIListLogsUseCase) ListLogs(ctx context.Context) ([]*domain.Log, error) {
+func (m *MockIListLogsUseCase) ListLogs(ctx context.Context) ([]*ListLogDto, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListLogs", ctx)
-	ret0, _ := ret[0].([]*domain.Log)
+	ret0, _ := ret[0].([]*ListLogDto)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }


### PR DESCRIPTION
## Issue Number
#33 
## Implementation Summary
This pull request implements the `HandleLogList` method in the presentation layer, enabling the retrieval and display of log records through an HTTP endpoint. The following modifications were made:
- Defined the `HandleLogList` method in the `MYSQLLogHandler` struct, allowing it to interact with the usecase layer to fetch log data.
- Configured the HTTP response to return the log data in JSON format, along with appropriate status codes based on the success or failure of the retrieval.

## Scope of Impact
- When invoked, the HTTP handler will retrieve all logs via the usecase layer and return them to the client in JSON format, enhancing the log visibility through the HTTP API.

## Particular Points to Check
- Ensure that the new `HandleLogList` method correctly handles both successful log retrieval and error conditions 
## Test
```
make test
```

![image](https://github.com/user-attachments/assets/3217ebfd-1a68-408d-9307-2705c39f3366)


## Schedule
10/27