### PR TITLE
[Server] Imprement logs endpoint that return log list

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"log"
-
 	"log_service/internal/server"
 )
 

--- a/internal/server/infrastructure/di/log.go
+++ b/internal/server/infrastructure/di/log.go
@@ -25,11 +25,19 @@ func BuildLogContainer() (*dig.Container, error) {
 		return nil, err
 	}
 
+	if err := container.Provide(usecase.NewListLogsUseCase, dig.As(new(usecase.IListLogsUseCase))); err != nil {
+		return nil, err
+	}
+
 	if err := container.Provide(rabbitmq.Connect); err != nil {
 		return nil, err
 	}
 
 	if err := container.Provide(presentation.NewAMQPLogHandler); err != nil {
+		return nil, err
+	}
+
+	if err := container.Provide(presentation.NewHttpLogHandler); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Issue Number
#46 

## Implementation Summary
This pull request implements the presenter layer for the `/logs` endpoint. The presenter layer formats the data from the use case layer before sending it as a response. Key changes include:
- Creation of a `Presenter` interface and its implementation.
- Integration of the presenter layer into the `HttpLogHandler` for the `/logs` endpoint.
- Updated response handling to ensure properly formatted output, including handling empty logs gracefully.
- Addition of unit tests to validate the presenter layer's behavior.

## Scope of Impact
- **Execution Timing**: This feature will be executed whenever a client makes a request to the `/logs` endpoint.
- **Value Changes**: The `/logs` endpoint will return responses processed by the presenter layer, ensuring consistent and properly formatted output.

## Particular Points to Check
- Ensure the presenter layer integration does not break existing functionality.
- Verify that the changes do not inadvertently impact other endpoints or parts of the application.
- Validate the handling of edge cases such as empty log results and unexpected errors.

## Test
```
➜  log_service git:(main) ✗ make send_message              
RABBITMQ_URL=amqp://guest:guest@localhost:5672/ go run ./cmd/client --log-level=debug --source-service=client --destination-service=server --request-type=POST --content="Hello World!"
2024/11/16 23:45:18 Received response: code: 0, message: OK
 
log_service git:(main) ✗ curl http://localhost:8080/logs

[{"log_level":"debug","date":"2024-11-16T14:45:19Z","source_service":"client","destination_service":"server","request_type":"POST","content":"Hello World!"}]
➜  log_service git:(main) ✗ make send_message              
RABBITMQ_URL=amqp://guest:guest@localhost:5672/ go run ./cmd/client --log-level=debug --source-service=client --destination-service=server --request-type=POST --content="Hello World!"
2024/11/17 00:08:10 Received response: code: 0, message: OK
➜  log_service git:(feature/#46_Imprement_logs_endpoint_that_return_log_list) ✗ curl http://localhost:8080/logs                                                

[{"log_level":"debug","date":"2024-11-16T14:45:19Z","source_service":"client","destination_service":"server","request_type":"POST","content":"Hello World!"},{"log_level":"debug","date":"2024-11-16T15:08:11Z","source_service":"client","destination_service":"server","request_type":"POST","content":"Hello World!"}]
➜  log_service git:(feature/#46_Imprement_logs_endpoint_that_return_log_list) ✗ 


```

## Schedule
11/23