### PR TITLE
[SDK] Implement a Writer to pass logs to the logger

### DIFF
--- a/examples/log/main.go
+++ b/examples/log/main.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"time"
+
+	"log_service/pkg/logger"
+	"log_service/pkg/rabbitmq"
+)
+
+func init() {
+	log.SetFlags(0)
+}
+
+func main() {
+	conn, ch, err := rabbitmq.Connect()
+	if err != nil {
+		panic(err)
+	}
+	defer conn.Close()
+	defer ch.Close()
+
+	ctx := context.Background()
+	w, err := logger.NewWritter(ctx, ch)
+	if err != nil {
+		panic(err)
+	}
+	log.SetOutput(w)
+
+	num := 10
+	var sumSec int64 = 0
+	for i := 0; i < num; i++ {
+		t := time.Now()
+		log.Println("Hello, World!")
+		sec := time.Since(t).Milliseconds()
+		sumSec += sec
+		fmt.Printf("%vms\n", sec)
+	}
+
+	fmt.Printf("Average: %vms\n", int(sumSec)/num)
+}

--- a/internal/client/run.go
+++ b/internal/client/run.go
@@ -1,8 +1,6 @@
 package client
 
 import (
-	"github.com/google/uuid"
-
 	"log_service/internal/client/infrastructure/rabbitmq"
 	clientPresentation "log_service/internal/client/presentation"
 	"log_service/internal/client/usecase"
@@ -17,9 +15,7 @@ func Run(req presentation.AMQPLogRequest) error {
 	defer conn.Close()
 	defer ch.Close()
 
-	corrID := uuid.New().String()
-
-	logPresentation := clientPresentation.NewLogPresentation(ch, corrID)
+	logPresentation := clientPresentation.NewLogPresentation(ch)
 	logUseCase := usecase.NewInsertLogUseCase(logPresentation)
 
 	return logUseCase.Serve(req)

--- a/internal/client/usecase/insert_log.go
+++ b/internal/client/usecase/insert_log.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"github.com/google/uuid"
+
 	clientPresentation "log_service/internal/client/presentation"
 	"log_service/internal/server/presentation"
 )
@@ -31,9 +33,11 @@ func (u *InsertLogUseCase) Serve(req presentation.AMQPLogRequest) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	if err := u.logPresentation.Publish(ctx, qName, req); err != nil {
+	corrID := uuid.New().String()
+
+	if err := u.logPresentation.Publish(ctx, qName, corrID, req); err != nil {
 		return err
 	}
 
-	return u.logPresentation.Serve(msgs)
+	return u.logPresentation.Serve(msgs, corrID)
 }

--- a/pkg/logger/writter.go
+++ b/pkg/logger/writter.go
@@ -1,0 +1,50 @@
+package logger
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	amqp "github.com/rabbitmq/amqp091-go"
+
+	"log_service/internal/client/presentation"
+	serverPresentation "log_service/internal/server/presentation"
+)
+
+type Writter struct {
+	ch              *amqp.Channel
+	logPresentation presentation.ILogPresentation
+	queue           string
+	msgs            <-chan amqp.Delivery
+}
+
+func NewWritter(ctx context.Context, ch *amqp.Channel) (*Writter, error) {
+	logPresentation := presentation.NewLogPresentation(ch)
+	msgs, queue, err := logPresentation.Consume()
+	if err != nil {
+		return nil, err
+	}
+	w := &Writter{
+		ch:              ch,
+		logPresentation: logPresentation,
+		queue:           queue,
+		msgs:            msgs,
+	}
+	return w, nil
+}
+
+func (w *Writter) Write(p []byte) (n int, err error) {
+	req := serverPresentation.AMQPLogRequest{
+		Date:    time.Now(),
+		Content: string(p),
+	}
+
+	id := uuid.New().String()
+	if err := w.logPresentation.Publish(context.Background(), w.queue, id, req); err != nil {
+		return 0, err
+	}
+	if err := w.logPresentation.Serve(w.msgs, id); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}

--- a/pkg/rabbitmq/connect.go
+++ b/pkg/rabbitmq/connect.go
@@ -1,0 +1,12 @@
+package rabbitmq
+
+import (
+	amqp "github.com/rabbitmq/amqp091-go"
+
+	"log_service/internal/client/infrastructure/rabbitmq"
+)
+
+func Connect() (*amqp.Connection, *amqp.Channel, error) {
+	conn, ch, err := rabbitmq.Connect()
+	return conn, ch, err
+}


### PR DESCRIPTION
## Issue Number
#49 

## Implementation Summary
We implemented a Writer that can be configured as the standard log output and created an example to measure the performance of log output.

## Scope of Impact
- `pkg/logger`: Create a logger to send logs to the `log_service`.
- `pkg/rabbitmq`: Implement a package to connect to RabbitMQ.
- `example/logger`: Implement a sample code demonstrating how to use the contents passed to the `pkg`.

## Particular points to check
- Is the division into `internal`, `pkg`, and `example` appropriate?  
- Is the implementation of the Writer appropriate?

## Test
```
# Set up `log_service`
$ make up
# Run the sample applications
$ RABBITMQ_URL=amqp://guest:guest@localhost:5672/ go run ./examples/log
8ms
2ms
1ms
3ms
2ms
2ms
1ms
1ms
1ms
1ms
Average: 2ms
```
