### PR TITLE
[Server]Enable access to the frontend service

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -26,6 +26,10 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
+    networks:
+      - logging_network
 
   phpmyadmin:
     image: phpmyadmin
@@ -35,6 +39,9 @@ services:
       - .env
     ports:
       - "3001:80"
+    networks:
+      - logging_network
+
   db:
     image: mysql:8
     restart: always
@@ -50,6 +57,9 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - logging_network
+
   rabbitmq:
     image: rabbitmq:3-management
     ports:
@@ -57,7 +67,18 @@ services:
       - 15672:15672
     volumes:
       - rabbitmq_data:/var/lib/rabbitmq
+    networks:
+      - logging_network
+    healthcheck:
+      test: ["CMD", "rabbitmqctl", "node_health_check"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 volumes:
   db-data:
   rabbitmq_data:
+
+networks:
+  logging_network:
+    external: true


### PR DESCRIPTION
## issue
#67 
## Implementation Summary
This pull request modifies the docker-compose setup, ensuring that the frontend service is now properly connected to the logging service’s network, allowing log data to be transmitted smoothly.

## Scope of Impact
Changes will take effect upon redeployment. With this update, the log routing will be adjusted so that logs previously retained in the frontend are now forwarded to the logging service.

## Particular points to check
Verify that the new network configuration doesn’t interfere with existing services or introduce unexpected dependencies. Ensure that the logging service still functions as intended for other parts of the system.

## Test
X-Clone
```
make up
```
Twitter-Clone(TS)
```
➜  ts git:(feature/#529_Enable_access_to_the_logging_service) ✗ d
ocker compose build
docker compose up -d
docker compose exec app bash
```

```
root@290a43ac81c5:/app/twitter# nc -vz rabbitmq 5672
Connection to rabbitmq (172.20.0.5) 5672 port [tcp/amqp] succeeded!
```
Log-service
```
make up
```

## Schedule
Target merge date: 12/21