### PR TITLE
[Server] Add eventType field to CTRLog entity to distinguish impression logs from click ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,3 +40,6 @@ send_message:
 
 create_doc:
 	godoc -http=localhost:${GODOC_PORT}
+
+format:
+	go fmt ./...

--- a/internal/server/domain/log.go
+++ b/internal/server/domain/log.go
@@ -11,9 +11,16 @@ type Log struct {
 	Content            string
 }
 
+// CTRLog represents a log entry for tracking user interactions with a page element.
+//
+// The zero value of CTRLog is not valid for use; values should be explicitly initialized.
 type CTRLog struct {
+	// EventType specifies the type of interaction, such as "click" or "impression".
+	EventType string
+	// CreatedAt is the timestamp when the event occurred.
 	CreatedAt time.Time
-	Objectid  string
+	// ObjectID uniquely identifies the page element associated with the event.
+	ObjectID string
 }
 
 func NewLog(
@@ -34,11 +41,21 @@ func NewLog(
 	}
 }
 
+// NewCTRLog creates a new CTRLog instance with the specified event type,
+// creation timestamp, and associated object ID.
+//
+// eventType indicates the type of interaction, such as "click" or "impression".
+// createdAt specifies the timestamp when the event occurred.
+// objectid uniquely identifies the page element related to the event.
+//
+// Returns a pointer to a CTRLog instance initialized with the provided values.
 func NewCTRLog(
+	eventType string,
 	createdAt time.Time,
 	objectid string,
 ) *CTRLog {
 	return &CTRLog{
+		EventType: eventType,
 		CreatedAt: createdAt,
 		Objectid:  objectid,
 	}

--- a/internal/server/domain/log_test.go
+++ b/internal/server/domain/log_test.go
@@ -38,13 +38,15 @@ func TestNewLog(t *testing.T) {
 	}
 }
 
+// TestNewCTRLog tests the NewCTRLog function
 func TestNewCTRLog(t *testing.T) {
 	// Setup test data
+	eventType := "click"
 	createdAt := time.Now()
 	objectid := "123456"
 
 	// Call the function
-	ctrLog := NewCTRLog(createdAt, objectid)
+	ctrLog := NewCTRLog(eventType, createdAt, objectid)
 
 	// Check if the log is populated correctly
 	if ctrLog.CreatedAt != createdAt {
@@ -52,5 +54,8 @@ func TestNewCTRLog(t *testing.T) {
 	}
 	if ctrLog.Objectid != objectid {
 		t.Errorf("Expected Objectid %s, got %s", objectid, ctrLog.Objectid)
+	}
+	if ctrLog.EventType != eventType {
+		t.Errorf("Expected EventType %s, got %s", eventType, ctrLog.EventType)
 	}
 }


### PR DESCRIPTION
## Issue Number
#74 

## Background
In the frontend, retrieving only the `objectId` was necessary to determine which page element it belonged to. However, it was insufficient to distinguish between an impression and a click.  

To address this, we updated the table design and added a new `eventType` column. This allows us to separately track clicks and impressions, which is essential for calculating CTR (Click-Through Rate) by dividing the number of clicks by the number of impressions.

## Implementation Summary
Same as title.

## Test
![image](https://github.com/user-attachments/assets/560b058a-b5a5-47cc-a9eb-b516d1dae7d2)

## Schedule
2/25