### PR TITLE
[Server] Implement ctr log usecase layer to save them

### DIFF
--- a/internal/server/usecase/insert_log.go
+++ b/internal/server/usecase/insert_log.go
@@ -11,12 +11,29 @@ type IInsertLogUseCase interface {
 	InsertLog(ctx context.Context, dto *InsertLogDto) error
 }
 
+// IInsertCTRLogUseCase is an interface for inserting CTR logs.
+type IInsertCTRLogUseCase interface {
+	InsertCTRLog(ctx context.Context, dto *InsertCTRLogDto) error
+}
+
 type InsertLogUseCase struct {
+	logRepository domain.ILogRepository
+}
+
+// InsertLogUseCase is a use case for inserting log entries into the database.
+type InsertCTRLogUseCase struct {
 	logRepository domain.ILogRepository
 }
 
 func NewInsertLogUseCase(logRepository domain.ILogRepository) *InsertLogUseCase {
 	return &InsertLogUseCase{
+		logRepository: logRepository,
+	}
+}
+
+// NewInsertCTRLogUseCase creates a new instance of InsertCTRLogUseCase with the given log repository.
+func NewInsertCTRLogUseCase(logRepository domain.ILogRepository) *InsertCTRLogUseCase {
+	return &InsertCTRLogUseCase{
 		logRepository: logRepository,
 	}
 }
@@ -30,6 +47,13 @@ type InsertLogDto struct {
 	Content            string
 }
 
+// InsertCTRLogDto is a data transfer object for inserting CTR logs.
+type InsertCTRLogDto struct {
+	EventType string
+	CreatedAt time.Time
+	ObjectID  string
+}
+
 func (u *InsertLogUseCase) InsertLog(ctx context.Context, dto *InsertLogDto) error {
 	log := domain.NewLog(
 		dto.LogLevel,
@@ -40,4 +64,16 @@ func (u *InsertLogUseCase) InsertLog(ctx context.Context, dto *InsertLogDto) err
 		dto.Content,
 	)
 	return u.logRepository.Save(ctx, log)
+}
+
+// InsertCTRLog inserts a new CTR log entry into the database.
+// It takes a context and a CTRLogDto object as arguments.
+// It returns an error if the operation fails.
+func (u *InsertLogUseCase) InsertCTRLog(ctx context.Context, dto *InsertCTRLogDto) error {
+	ctrLog := domain.NewCTRLog(
+		dto.EventType,
+		dto.CreatedAt,
+		dto.ObjectID,
+	)
+	return u.logRepository.CTRSave(ctx, ctrLog)
 }

--- a/internal/server/usecase/insert_log_mock.go
+++ b/internal/server/usecase/insert_log_mock.go
@@ -53,3 +53,41 @@ func (mr *MockIInsertLogUseCaseMockRecorder) InsertLog(ctx, dto any) *gomock.Cal
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertLog", reflect.TypeOf((*MockIInsertLogUseCase)(nil).InsertLog), ctx, dto)
 }
+
+// MockIInsertCTRLogUseCase is a mock of IInsertCTRLogUseCase interface.
+type MockIInsertCTRLogUseCase struct {
+	ctrl     *gomock.Controller
+	recorder *MockIInsertCTRLogUseCaseMockRecorder
+	isgomock struct{}
+}
+
+// MockIInsertCTRLogUseCaseMockRecorder is the mock recorder for MockIInsertCTRLogUseCase.
+type MockIInsertCTRLogUseCaseMockRecorder struct {
+	mock *MockIInsertCTRLogUseCase
+}
+
+// NewMockIInsertCTRLogUseCase creates a new mock instance.
+func NewMockIInsertCTRLogUseCase(ctrl *gomock.Controller) *MockIInsertCTRLogUseCase {
+	mock := &MockIInsertCTRLogUseCase{ctrl: ctrl}
+	mock.recorder = &MockIInsertCTRLogUseCaseMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIInsertCTRLogUseCase) EXPECT() *MockIInsertCTRLogUseCaseMockRecorder {
+	return m.recorder
+}
+
+// InsertCTRLog mocks base method.
+func (m *MockIInsertCTRLogUseCase) InsertCTRLog(ctx context.Context, dto *InsertCTRLogDto) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertCTRLog", ctx, dto)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InsertCTRLog indicates an expected call of InsertCTRLog.
+func (mr *MockIInsertCTRLogUseCaseMockRecorder) InsertCTRLog(ctx, dto any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertCTRLog", reflect.TypeOf((*MockIInsertCTRLogUseCase)(nil).InsertCTRLog), ctx, dto)
+}

--- a/internal/server/usecase/insert_log_test.go
+++ b/internal/server/usecase/insert_log_test.go
@@ -59,4 +59,51 @@ func TestInsertLog(t *testing.T) {
 			}
 		})
 	}
+
+}
+
+func TestInsertCTRLog(t *testing.T) {
+	t.Parallel()
+
+	currTime := time.Now()
+
+	CTRtests := []struct {
+		name     string
+		dto      *InsertCTRLogDto
+		mockFunc func(*domain.MockILogRepository)
+	}{
+		{
+			name: "success",
+			dto: &InsertCTRLogDto{
+				EventType: "tap",
+				CreatedAt: currTime,
+				ObjectID:  "123",
+			},
+			mockFunc: func(m *domain.MockILogRepository) {
+				m.EXPECT().CTRSave(
+					gomock.Any(),
+					&domain.CTRLog{
+						EventType: "tap",
+						CreatedAt: currTime,
+						ObjectID:  "123",
+					},
+				).Return(nil)
+			},
+		},
+	}
+
+	for _, tt := range CTRtests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			mockUserRepo := domain.NewMockILogRepository(ctrl)
+			logInsertUseCase := NewInsertLogUseCase(mockUserRepo)
+			ctx := context.Background()
+			tt.mockFunc(mockUserRepo)
+			err := logInsertUseCase.InsertCTRLog(ctx, tt.dto)
+			if err != nil {
+				t.Errorf("InsertCTRLog() error = %v", err)
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Issue Number
#81 
## Implementation Summary
This pull request implements the CTR log use case layer to save CTR logs efficiently. It introduces a new `InsertCTRLogUseCase` and integrates it with the existing logging system.  

## Scope of Impact
This will be executed when a CTR log is generated and needs to be persisted. The changes affect the log processing layer by introducing a structured way to handle CTR logs separately.  

## Particular points to check 
Ensure that the new use case does not interfere with the existing log saving process. Also, verify that the repository layer correctly handles CTR log persistence without side effects.  

## Test  
![image](https://github.com/user-attachments/assets/e926b26a-8cb2-498b-98e0-e3589af997f0)


## Schedule
3/8