### PR TITLE
[Server] Implement server layer to run handling ctr log while server running

### DIFF
--- a/internal/server/infrastructure/di/log.go
+++ b/internal/server/infrastructure/di/log.go
@@ -29,6 +29,10 @@ func BuildLogContainer() (*dig.Container, error) {
 		return nil, err
 	}
 
+	if err := container.Provide(usecase.NewInsertCTRLogUseCase, dig.As(new(usecase.IInsertCTRLogUseCase))); err != nil {
+		return nil, err
+	}
+
 	if err := container.Provide(rabbitmq.Connect); err != nil {
 		return nil, err
 	}
@@ -38,6 +42,10 @@ func BuildLogContainer() (*dig.Container, error) {
 	}
 
 	if err := container.Provide(presentation.NewHttpLogHandler); err != nil {
+		return nil, err
+	}
+
+	if err := container.Provide(presentation.NewAMQPCTRLogHandler); err != nil {
 		return nil, err
 	}
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -30,8 +30,9 @@ func Run() error {
 		dbConn *sql.DB,
 		amqpConn *amqp091.Connection,
 		amqpCh *amqp091.Channel,
-		amqpMsgs <-chan amqp091.Delivery,
+		amqpCTRMsgs <-chan amqp091.Delivery,
 		amqpLogHandler *presentation.AMQPLogHandler,
+		amqpCtrLogHandler *presentation.AMQPCTRLogHandler,
 		httpLogHander *presentation.HttpLogHandler,
 	) {
 		defer dbConn.Close()
@@ -40,13 +41,9 @@ func Run() error {
 
 		done := make(chan bool)
 		go func() {
-			for d := range amqpMsgs {
-				amqpLogHandler.HandleLog(d)
-				if err := d.Ack(false); err != nil {
-					log.Fatalf("Failed to ack message: %v", err)
-				}
+			for d := range amqpCTRMsgs {
+				amqpCtrLogHandler.HandleCTRLog(d)
 			}
-			done <- true
 		}()
 
 		mux := http.NewServeMux()

--- a/internal/server/usecase/insert_log.go
+++ b/internal/server/usecase/insert_log.go
@@ -69,7 +69,7 @@ func (u *InsertLogUseCase) InsertLog(ctx context.Context, dto *InsertLogDto) err
 // InsertCTRLog inserts a new CTR log entry into the database.
 // It takes a context and a CTRLogDto object as arguments.
 // It returns an error if the operation fails.
-func (u *InsertLogUseCase) InsertCTRLog(ctx context.Context, dto *InsertCTRLogDto) error {
+func (u *InsertCTRLogUseCase) InsertCTRLog(ctx context.Context, dto *InsertCTRLogDto) error {
 	ctrLog := domain.NewCTRLog(
 		dto.EventType,
 		dto.CreatedAt,

--- a/internal/server/usecase/insert_log_test.go
+++ b/internal/server/usecase/insert_log_test.go
@@ -97,10 +97,10 @@ func TestInsertCTRLog(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
 			mockUserRepo := domain.NewMockILogRepository(ctrl)
-			logInsertUseCase := NewInsertLogUseCase(mockUserRepo)
+			ctrLogInsertUseCase := NewInsertCTRLogUseCase(mockUserRepo)
 			ctx := context.Background()
 			tt.mockFunc(mockUserRepo)
-			err := logInsertUseCase.InsertCTRLog(ctx, tt.dto)
+			err := ctrLogInsertUseCase.InsertCTRLog(ctx, tt.dto)
 			if err != nil {
 				t.Errorf("InsertCTRLog() error = %v", err)
 			}


### PR DESCRIPTION
## Issue Number
#87  

## Implementation Summary
Added a server layer to process incoming logs and store them in the database. Additionally, identified and fixed an issue in the usecase layer as part of this PR.  

## Background
- Implementing a **naive** approach quickly was prioritized.  
- As this is part of the **CTR log project**, the previous log implementation is no longer necessary.  
- The next task includes **removing unnecessary parts** from the existing implementation.  
- Currently, `HandleLog` in `server.go` has been replaced with `HandleCTRLog`, but since the previous implementation is no longer needed, this change does not pose an issue.  


## Test
```
➜  log_service git:(feature/87_Implement_server_layer_to_handle_ctr_logs_while_server_running) ✗ make up
docker compose up -d --build
[+] Building 18.9s (18/18) FINISHED                                                                                                                              
 => [internal] load build definition from Dockerfile                                                                                                        0.0s
 => => transferring dockerfile: 32B                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                           0.0s
 => => transferring context: 35B                                                                                                                            0.0s
 => resolve image config for docker.io/docker/dockerfile:1                                                                                                  0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:1                                                                                                     0.0s
 => [internal] load build definition from Dockerfile                                                                                                        0.0s
 => [internal] load metadata for docker.io/library/golang:1.23.0                                                                                            0.0s
 => [internal] load metadata for docker.io/library/alpine:latest                                                                                            0.0s
 => [internal] load .dockerignore                                                                                                                           0.0s
 => [build 1/4] FROM docker.io/library/golang:1.23.0                                                                                                        0.0s
 => [internal] load build context                                                                                                                           0.0s
 => => transferring context: 13.68kB                                                                                                                        0.0s
 => [final 1/4] FROM docker.io/library/alpine:latest                                                                                                        0.0s
 => CACHED [build 2/4] WORKDIR /src                                                                                                                         0.0s
 => CACHED [build 3/4] RUN --mount=type=cache,target=/go/pkg/mod/     --mount=type=bind,source=go.sum,target=go.sum     --mount=type=bind,source=go.mod,ta  0.0s
 => [build 4/4] RUN --mount=type=cache,target=/go/pkg/mod/     --mount=type=bind,target=.     CGO_ENABLED=0 GOARCH=arm64 go build -o /bin/server ./cmd/se  18.2s
 => CACHED [final 2/4] RUN --mount=type=cache,target=/var/cache/apk     apk --update add     ca-certificates     tzdata     &&     update-ca-certificates   0.0s
 => CACHED [final 3/4] RUN adduser     --disabled-password     --gecos ""     --home "/nonexistent"     --shell "/sbin/nologin"     --no-create-home     -  0.0s
 => CACHED [final 4/4] COPY --from=build /bin/server /bin/                                                                                                  0.0s
 => exporting to image                                                                                                                                      0.0s
 => => exporting layers                                                                                                                                     0.0s
 => => writing image sha256:9c3a1bf49f5ac2643e8203f4269743f9faecf051a63ab7465d8389004c11add9                                                                0.0s
 => => naming to docker.io/library/log_service-server                                                                                                       0.0s
[+] Running 7/7
 ⠿ Network log_service_default         Created                                                                                                              0.1s
 ⠿ Volume "log_service_rabbitmq_data"  Created                                                                                                              0.0s
 ⠿ Volume "log_service_db-data"        Created                                                                                                              0.0s
 ⠿ Container log_service-rabbitmq-1    Started                                                                                                              1.8s
 ⠿ Container log_service-db-1          Healthy                                                                                                             22.9s
 ⠿ Container log_service-phpmyadmin-1  Started                                                                                                              2.7s
 ⠿ Container log_service-server-1      Started                                                                                                             23.5s
➜  log_service git:(feature/87_Implement_server_layer_to_handle_ctr_logs_while_server_running) ✗ make migrate_up 
migrate -path internal/server/infrastructure/mysql/db/schema -database "mysql://root:password@tcp(localhost:3306)/example" up
1/u log (27.334833ms)
2/u ctr_log (50.260625ms)

➜  log_service git:(feature/87_Implement_server_layer_to_handle_ctr_logs_while_server_running) ✗ docker exec -it log_service-rabbitmq-1 rabbitmqadmin publish exchange=amq.default routing_key=logs payload='{"eventType":"click","createdAt":"2025-03-17T12:00:00Z","objectId":"12345"}'
Message published
➜  log_service git:(feature/87_Implement_server_layer_to_handle_ctr_logs_while_server_running) ✗ docker exec -it log_service-db-1 mysql -u root -p example -e "SELECT * FROM ctr_logs ORDER BY created_at DESC;"

Enter password: 
+------------+---------------------+-----------+
| event_type | created_at          | object_id |
+------------+---------------------+-----------+
| click      | 2025-03-17 12:00:00 | 12345     |
+------------+---------------------+-----------+

```
## Schedule
3/22